### PR TITLE
Harden YouTube URL validation for music queue

### DIFF
--- a/src/modules/music/MusicService.js
+++ b/src/modules/music/MusicService.js
@@ -69,6 +69,79 @@ function extractChannelName(video) {
   );
 }
 
+const YOUTUBE_VIDEO_ID_REGEX = /^[\w-]{11}$/;
+const INVALID_VIDEO_ID_PLACEHOLDERS = new Set([
+  "undefined",
+  "deleted video",
+  "private video"
+]);
+
+function normalizeVideoId(candidate) {
+  if (typeof candidate !== "string") return null;
+
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) return null;
+
+  const normalized = trimmed.toLowerCase();
+  if (INVALID_VIDEO_ID_PLACEHOLDERS.has(normalized)) {
+    return null;
+  }
+
+  if (!YOUTUBE_VIDEO_ID_REGEX.test(trimmed)) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+function extractVideoIdFromUrl(url) {
+  if (typeof url !== "string") {
+    return { videoId: null, isYoutube: false };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    return { videoId: null, isYoutube: false };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { videoId: null, isYoutube: false };
+  }
+
+  const hostname = parsed.hostname.replace(/^www\./i, "").toLowerCase();
+  const isYoutube =
+    hostname === "youtu.be" ||
+    hostname.endsWith("youtube.com") ||
+    hostname.endsWith("youtube-nocookie.com");
+
+  if (!isYoutube) {
+    return { videoId: null, isYoutube: false };
+  }
+
+  if (hostname === "youtu.be") {
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length === 0) return { videoId: null, isYoutube: true };
+    return { videoId: normalizeVideoId(segments[0]), isYoutube: true };
+  }
+
+  const directId = normalizeVideoId(parsed.searchParams.get("v"));
+  if (directId) {
+    return { videoId: directId, isYoutube: true };
+  }
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length >= 2) {
+    const [first, second] = segments;
+    if (["embed", "shorts", "live", "v"].includes(first)) {
+      return { videoId: normalizeVideoId(second), isYoutube: true };
+    }
+  }
+
+  return { videoId: null, isYoutube: true };
+}
+
 function extractVideoId(video) {
   if (!video) return null;
 
@@ -83,8 +156,9 @@ function extractVideoId(video) {
   ];
 
   for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate.trim();
+    const normalized = normalizeVideoId(candidate);
+    if (normalized) {
+      return normalized;
     }
   }
 
@@ -98,17 +172,19 @@ function resolveVideoUrl(video, fallbackUrl) {
     video?.short_url,
     video?.link,
     video?.permalink,
-    video?.webpage_url
+    video?.webpage_url,
+    fallbackUrl
   ];
 
   for (const candidate of candidates) {
-    if (isValidHttpUrl(candidate)) {
+    const { videoId: candidateVideoId, isYoutube } = extractVideoIdFromUrl(candidate);
+    if (candidateVideoId) {
+      return `https://www.youtube.com/watch?v=${candidateVideoId}`;
+    }
+
+    if (!isYoutube && isValidHttpUrl(candidate)) {
       return candidate;
     }
-  }
-
-  if (isValidHttpUrl(fallbackUrl)) {
-    return fallbackUrl;
   }
 
   const videoId = extractVideoId(video);


### PR DESCRIPTION
## Summary
- add helpers to normalize YouTube IDs and extract them from URLs while filtering deleted/private placeholders
- ensure resolveVideoUrl only returns canonical watch URLs for valid IDs and skips invalid YouTube entries while still allowing non-YouTube links

## Testing
- node - <<'NODE' ... (vm-run check of resolveVideoUrl/createTrackFromVideo handling valid vs invalid IDs)

------
https://chatgpt.com/codex/tasks/task_e_68ca759c851c832889d4379bc6ec632b