### PR TITLE
Add Chzzk streaming integration

### DIFF
--- a/data/chzzk.json
+++ b/data/chzzk.json
@@ -1,0 +1,3 @@
+{
+  "broadcaster": null
+}

--- a/src/commands/chzzk.js
+++ b/src/commands/chzzk.js
@@ -1,0 +1,141 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js");
+const { ensureChzzkService } = require("../modules/chzzk/helpers");
+const { searchChannels, getChannel } = require("../modules/chzzk/api");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("chzzk")
+    .setDescription("치지직 방송 알림을 설정합니다.")
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .addSubcommand(sub =>
+      sub.setName("register")
+        .setDescription("치지직 방송 닉네임을 등록합니다.")
+        .addStringOption(opt =>
+          opt.setName("nickname")
+            .setDescription("치지직 방송 닉네임")
+            .setRequired(true)
+        )
+    )
+    .addSubcommand(sub =>
+      sub.setName("clear")
+        .setDescription("등록된 치지직 방송인을 제거합니다.")
+    )
+    .addSubcommand(sub =>
+      sub.setName("status")
+        .setDescription("현재 등록된 치지직 방송 정보를 확인합니다.")
+    ),
+
+  async execute(interaction) {
+    const service = await ensureChzzkService(interaction);
+    if (!service) return;
+
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === "register") {
+      await handleRegister(interaction, service);
+      return;
+    }
+
+    if (subcommand === "clear") {
+      await handleClear(interaction, service);
+      return;
+    }
+
+    if (subcommand === "status") {
+      await handleStatus(interaction, service);
+    }
+  }
+};
+
+async function handleRegister(interaction, service) {
+  const nickname = interaction.options.getString("nickname", true).trim();
+  await interaction.deferReply({ ephemeral: true });
+
+  try {
+    const channel = interaction.channel;
+    if (!channel || typeof channel.isTextBased !== "function" || !channel.isTextBased()) {
+      await interaction.editReply("이 위치에서는 알림 채널을 설정할 수 없습니다. 텍스트 채널에서 다시 시도해주세요.");
+      return;
+    }
+
+    const candidates = await searchChannels(nickname, { size: 10 });
+    if (!candidates.length) {
+      await interaction.editReply(`\`${nickname}\` 닉네임으로 검색된 치지직 방송인이 없습니다.`);
+      return;
+    }
+
+    const normalized = nickname.toLowerCase();
+    const matched = candidates.find(entry => entry.channelName.toLowerCase() === normalized) || candidates[0];
+
+    const channelInfo = await getChannel(matched.channelId);
+    if (!channelInfo) {
+      await interaction.editReply("치지직 채널 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
+      return;
+    }
+
+    await service.registerBroadcaster({
+      channelId: matched.channelId,
+      channelName: matched.channelName,
+      notifyChannelId: channel.id,
+      profileImageUrl: matched.channelImageUrl,
+      isLive: channelInfo.openLive
+    });
+
+    const parts = [
+      `치지직 방송인이 **${matched.channelName}**(채널 ID: \`${matched.channelId}\`)으로 등록되었습니다.`,
+      `알림 채널: <#${channel.id}>`
+    ];
+
+    if (channelInfo.openLive) {
+      parts.push("현재 방송이 진행 중입니다. 방송 종료 후 다시 켜지면 알림이 전송됩니다.");
+    }
+
+    await interaction.editReply(parts.join("\n"));
+  } catch (error) {
+    console.error("치지직 방송인 등록 실패", error);
+    await interaction.editReply("치지직 API 요청 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+  }
+}
+
+async function handleClear(interaction, service) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const broadcaster = service.getBroadcaster();
+  if (!broadcaster) {
+    await interaction.editReply("등록된 치지직 방송인이 없습니다.");
+    return;
+  }
+
+  await service.clearBroadcaster();
+  await interaction.editReply(`치지직 방송인 **${broadcaster.channelName}** 등록을 해제했습니다.`);
+}
+
+async function handleStatus(interaction, service) {
+  const broadcaster = service.getBroadcaster();
+  if (!broadcaster) {
+    await interaction.reply({
+      content: "등록된 치지직 방송인이 없습니다.",
+      ephemeral: true
+    });
+    return;
+  }
+
+  const lines = [
+    `현재 등록된 방송인: **${broadcaster.channelName}**`,
+    `채널 ID: \`${broadcaster.channelId}\``,
+    `알림 채널: <#${broadcaster.notifyChannelId}>`,
+    `최근 상태: ${broadcaster.isLive ? "방송 중" : "오프라인"}`
+  ];
+
+  if (broadcaster.lastAnnouncedAt) {
+    const lastDate = new Date(broadcaster.lastAnnouncedAt);
+    if (!Number.isNaN(lastDate.getTime())) {
+      lines.push(`마지막 알림: <t:${Math.floor(lastDate.getTime() / 1000)}:R>`);
+    }
+  }
+
+  await interaction.reply({
+    content: lines.join("\n"),
+    ephemeral: true
+  });
+}

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,6 +1,7 @@
 const { Events } = require("discord.js");
 const { closeParty } = require("../modules/party/lifecycle");
 const { getPartyService } = require("../modules/party/helpers");
+const { getChzzkService } = require("../modules/chzzk/helpers");
 
 module.exports = {
   name: Events.ClientReady,
@@ -11,23 +12,31 @@ module.exports = {
     const partyService = getPartyService(client);
     if (!partyService) {
       console.warn("파티 서비스가 등록되지 않았습니다. 자동 정리 기능을 건너뜁니다.");
-      return;
+    } else {
+      await partyService.sweepExpired(async party => {
+        try {
+          await closeParty(client, partyService, party, "24시간 만료 자동 종료");
+        } catch (error) {
+          console.error("자동폭파 실패:", error.message);
+        }
+      });
+
+      partyService.startSweepScheduler(async party => {
+        try {
+          await closeParty(client, partyService, party, "24시간 만료 자동 종료");
+        } catch (error) {
+          console.error("자동폭파 실패:", error.message);
+        }
+      });
     }
 
-    await partyService.sweepExpired(async party => {
+    const chzzkService = getChzzkService(client);
+    if (chzzkService) {
       try {
-        await closeParty(client, partyService, party, "24시간 만료 자동 종료");
+        await chzzkService.start(client);
       } catch (error) {
-        console.error("자동폭파 실패:", error.message);
+        console.error("치지직 서비스 시작 실패", error);
       }
-    });
-
-    partyService.startSweepScheduler(async party => {
-      try {
-        await closeParty(client, partyService, party, "24시간 만료 자동 종료");
-      } catch (error) {
-        console.error("자동폭파 실패:", error.message);
-      }
-    });
+    }
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ if (ffmpegPath) {
 
 const { GatewayIntentBits, Partials } = require("discord.js");
 const BotClient = require("./core/BotClient");
-const { initializeServices, shutdownServices, partyService, musicService } = require("./services");
+const { initializeServices, shutdownServices, partyService, musicService, chzzkService } = require("./services");
 
 async function bootstrap() {
   const client = new BotClient({
@@ -18,6 +18,7 @@ async function bootstrap() {
   await initializeServices();
   client.registerService("party", partyService);
   client.registerService("music", musicService);
+  client.registerService("chzzk", chzzkService);
   await client.initialize();
   registerShutdownHandlers(client);
   await client.login(process.env.DISCORD_TOKEN);

--- a/src/modules/chzzk/ChzzkRepository.js
+++ b/src/modules/chzzk/ChzzkRepository.js
@@ -1,0 +1,48 @@
+const fs = require("fs");
+const path = require("path");
+
+class ChzzkRepository {
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.data = { broadcaster: null };
+  }
+
+  async load() {
+    try {
+      const raw = await fs.promises.readFile(this.filePath, "utf8");
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        this.data.broadcaster = parsed.broadcaster ?? null;
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        console.error("치지직 저장소 로드 실패", error);
+      }
+      await this.#ensureDirectory();
+      await this.#write();
+    }
+  }
+
+  async setBroadcaster(broadcaster) {
+    this.data.broadcaster = broadcaster ? { ...broadcaster } : null;
+    await this.#write();
+  }
+
+  getBroadcaster() {
+    const broadcaster = this.data.broadcaster;
+    return broadcaster ? { ...broadcaster } : null;
+  }
+
+  async #write() {
+    await this.#ensureDirectory();
+    const payload = JSON.stringify(this.data, null, 2);
+    await fs.promises.writeFile(this.filePath, payload, "utf8");
+  }
+
+  async #ensureDirectory() {
+    const dir = path.dirname(this.filePath);
+    await fs.promises.mkdir(dir, { recursive: true });
+  }
+}
+
+module.exports = ChzzkRepository;

--- a/src/modules/chzzk/ChzzkService.js
+++ b/src/modules/chzzk/ChzzkService.js
@@ -1,0 +1,122 @@
+const { getChannel } = require("./api");
+
+class ChzzkService {
+  constructor(repository, { pollInterval = 60_000 } = {}) {
+    this.repository = repository;
+    this.pollInterval = pollInterval;
+    this.broadcaster = null;
+    this.timer = null;
+    this.client = null;
+    this._checking = false;
+  }
+
+  async initialize() {
+    await this.repository.load();
+    this.broadcaster = this.repository.getBroadcaster();
+  }
+
+  async start(client) {
+    this.client = client;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+
+    await this.#runCheck();
+    this.timer = setInterval(() => {
+      this.#runCheck();
+    }, this.pollInterval);
+  }
+
+  async shutdown() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.client = null;
+  }
+
+  getBroadcaster() {
+    return this.broadcaster ? { ...this.broadcaster } : null;
+  }
+
+  async registerBroadcaster({ channelId, channelName, notifyChannelId, profileImageUrl = null, isLive = false }) {
+    this.broadcaster = {
+      channelId,
+      channelName,
+      notifyChannelId,
+      profileImageUrl,
+      isLive: Boolean(isLive),
+      lastAnnouncedAt: null
+    };
+    await this.repository.setBroadcaster(this.broadcaster);
+    await this.#runCheck();
+  }
+
+  async clearBroadcaster() {
+    this.broadcaster = null;
+    await this.repository.setBroadcaster(null);
+  }
+
+  async #runCheck() {
+    if (this._checking) return;
+    this._checking = true;
+    try {
+      await this.#checkAndAnnounce();
+    } catch (error) {
+      console.error("치지직 상태 확인 실패", error);
+    } finally {
+      this._checking = false;
+    }
+  }
+
+  async #checkAndAnnounce() {
+    if (!this.broadcaster) return;
+
+    const channelInfo = await getChannel(this.broadcaster.channelId).catch(error => {
+      console.error("치지직 채널 조회 실패", error);
+      return null;
+    });
+
+    if (!channelInfo) {
+      return;
+    }
+
+    const isLive = Boolean(channelInfo.openLive);
+    const wasLive = Boolean(this.broadcaster.isLive);
+
+    if (isLive && !wasLive) {
+      await this.#announceLive();
+      this.broadcaster.lastAnnouncedAt = new Date().toISOString();
+    }
+
+    if (wasLive !== isLive) {
+      this.broadcaster.isLive = isLive;
+      await this.repository.setBroadcaster(this.broadcaster);
+    }
+  }
+
+  async #announceLive() {
+    if (!this.client) return;
+
+    let channel = null;
+    try {
+      channel = await this.client.channels.fetch(this.broadcaster.notifyChannelId);
+    } catch (error) {
+      console.error("치지직 알림 채널 조회 실패", error);
+      return;
+    }
+
+    if (!channel || typeof channel.send !== "function") {
+      console.warn("치지직 알림 채널에 메시지를 보낼 수 없습니다.");
+      return;
+    }
+
+    const message = `📺 ${this.broadcaster.channelName}님의 방송이 켜졌습니다!\nhttps://chzzk.naver.com/live/${this.broadcaster.channelId}`;
+    await channel.send({ content: message }).catch(error => {
+      console.error("치지직 방송 알림 전송 실패", error);
+    });
+  }
+}
+
+module.exports = ChzzkService;

--- a/src/modules/chzzk/api.js
+++ b/src/modules/chzzk/api.js
@@ -1,0 +1,91 @@
+const https = require("https");
+const dns = require("dns");
+
+const BASE_URL = "https://api.chzzk.naver.com/service/v1/";
+const DEFAULT_HEADERS = {
+  "User-Agent": "Mozilla/5.0 (compatible; HolsteinLandBot/1.0; +https://github.com/holstein-land)",
+  "Accept": "application/json",
+  "Referer": "https://chzzk.naver.com"
+};
+
+const LOOKUP_HINTS = (dns.ADDRCONFIG || 0) | (dns.V4MAPPED || 0);
+
+function lookup(hostname, options, callback) {
+  const merged = { ...options, family: 4, hints: LOOKUP_HINTS };
+  return dns.lookup(hostname, merged, callback);
+}
+
+async function request(path, { params } = {}) {
+  const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
+  const url = new URL(normalizedPath, BASE_URL);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, {
+      method: "GET",
+      headers: DEFAULT_HEADERS,
+      lookup
+    }, res => {
+      const chunks = [];
+      res.on("data", chunk => chunks.push(chunk));
+      res.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8");
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`Chzzk API 요청 실패 (${res.statusCode})`));
+          return;
+        }
+
+        let payload;
+        try {
+          payload = JSON.parse(body);
+        } catch (error) {
+          reject(new Error("Chzzk API 응답 파싱 실패"));
+          return;
+        }
+
+        if (payload.code !== 200) {
+          const message = payload.message || "알 수 없는 오류";
+          reject(new Error(`Chzzk API 오류: ${message}`));
+          return;
+        }
+
+        resolve(payload.content);
+      });
+    });
+
+    req.on("error", reject);
+    req.setTimeout(10_000, () => {
+      req.destroy(new Error("Chzzk API 요청이 시간 초과되었습니다."));
+    });
+    req.end();
+  });
+}
+
+async function searchChannels(keyword, { size = 10 } = {}) {
+  if (!keyword) return [];
+  const content = await request("search/channels", {
+    params: {
+      keyword,
+      size
+    }
+  });
+  if (!content?.data) return [];
+  return content.data
+    .map(entry => entry?.channel)
+    .filter(Boolean);
+}
+
+async function getChannel(channelId) {
+  if (!channelId) return null;
+  return await request(`channels/${channelId}`);
+}
+
+module.exports = {
+  searchChannels,
+  getChannel
+};

--- a/src/modules/chzzk/helpers.js
+++ b/src/modules/chzzk/helpers.js
@@ -1,0 +1,35 @@
+function getChzzkService(client) {
+  if (!client || typeof client.getService !== "function") {
+    return null;
+  }
+  return client.getService("chzzk") ?? null;
+}
+
+async function ensureChzzkService(interaction) {
+  const service = getChzzkService(interaction?.client);
+  if (service) {
+    return service;
+  }
+
+  if (!interaction) {
+    return null;
+  }
+
+  const payload = {
+    content: "치지직 연동 서비스가 아직 준비되지 않았습니다. 잠시 후 다시 시도해주세요.",
+    ephemeral: true
+  };
+
+  if (interaction.deferred || interaction.replied) {
+    await interaction.followUp(payload).catch(() => null);
+  } else {
+    await interaction.reply(payload).catch(() => null);
+  }
+
+  return null;
+}
+
+module.exports = {
+  getChzzkService,
+  ensureChzzkService
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,24 +2,31 @@ const path = require("path");
 const PartyRepository = require("../modules/party/PartyRepository");
 const PartyService = require("../modules/party/PartyService");
 const MusicService = require("../modules/music/MusicService");
+const ChzzkRepository = require("../modules/chzzk/ChzzkRepository");
+const ChzzkService = require("../modules/chzzk/ChzzkService");
 
 const partyRepository = new PartyRepository(path.join(__dirname, "../../data/parties.json"));
 const partyService = new PartyService(partyRepository);
 const musicService = new MusicService();
+const chzzkRepository = new ChzzkRepository(path.join(__dirname, "../../data/chzzk.json"));
+const chzzkService = new ChzzkService(chzzkRepository);
 
 async function initializeServices() {
   await partyService.initialize();
-  return { party: partyService, music: musicService };
+  await chzzkService.initialize();
+  return { party: partyService, music: musicService, chzzk: chzzkService };
 }
 
 async function shutdownServices() {
   partyService.stopSweepScheduler();
   await musicService.shutdown();
+  await chzzkService.shutdown();
 }
 
 module.exports = {
   initializeServices,
   shutdownServices,
   partyService,
-  musicService
+  musicService,
+  chzzkService
 };


### PR DESCRIPTION
## Summary
- add a persistent Chzzk service that polls for the registered broadcaster and posts Discord alerts when their stream goes live
- add a `/chzzk` slash command so admins can register, clear, or view the configured broadcaster and store the nickname in JSON
- wire the new service into the bot lifecycle and seed the repository with a default data file

## Testing
- `node - <<'NODE'
const { searchChannels, getChannel } = require('./src/modules/chzzk/api');
(async () => {
  try {
    const list = await searchChannels('트위치', { size: 1 });
    console.log('search result length', list.length);
    if (list[0]) {
      const info = await getChannel(list[0].channelId);
      console.log('channel keys', Object.keys(info).slice(0,5));
    }
  } catch (error) {
    console.error('API test failed', error);
  }
})();
NODE` *(fails in the container with ENETUNREACH network errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cab43345288328a901d573e7d5d4fe